### PR TITLE
cli: add filters for 'floco list'

### DIFF
--- a/lib/overlay.lib.nix
+++ b/lib/overlay.lib.nix
@@ -59,6 +59,7 @@ in {
     ./closures.nix
     ./graph
     ./update-pdef.nix
+    ./pdef-filters.nix
   ] ) // ( import ./url-code.nix );
   libdoc = callLib ./mdoc.nix;
 

--- a/lib/pdef-filters.nix
+++ b/lib/pdef-filters.nix
@@ -1,0 +1,74 @@
+# ============================================================================ #
+#
+#
+#
+# ---------------------------------------------------------------------------- #
+
+{ lib }: let
+
+# ---------------------------------------------------------------------------- #
+
+  noArgs = {
+
+# ---------------------------------------------------------------------------- #
+
+    hasInstall = p: p.lifecycle.install or false;
+    hasBuild   = p: p.lifecycle.build   or false;
+
+
+# ---------------------------------------------------------------------------- #
+
+    isLocal   = p: p.fetchInfo.type == "path";
+    isRemote  = p: p.fetchInfo.type != "path";
+    isGit     = p: builtins.elem p.fetchInfo.type ["git" "github" "gitlab"];
+    isTarball = p: p.fetchInfo.type == "tarball";
+
+
+# ---------------------------------------------------------------------------- #
+
+    hasPeers   = p: p.peerInfo != {};
+    hasBundled = p:
+      builtins.any ( de: de.bundled or false )
+                   ( builtins.attrValues p.depInfo );
+
+
+# ---------------------------------------------------------------------------- #
+
+    needsOS          = p: p.sysInfo.os  != ["*"];
+    needsCPU         = p: p.sysInfo.cpu != ["*"];
+    needsNodeVersion = p: ( p.sysInfo.engines.node or "*" ) != "*";
+
+
+# ---------------------------------------------------------------------------- #
+
+  };  # End `noArgs'
+
+
+# ---------------------------------------------------------------------------- #
+
+  withArgs = {
+
+    supportsOS = os: p:
+      ( builtins.elem "*" p.sysInfo.os ) ||
+      ( builtins.elem os p.sysInfo.os );
+
+    supportsCPU = cpu: p:
+      ( builtins.elem "*" p.sysInfo.cpu ) ||
+      ( builtins.elem cpu p.sysInfo.cpu );
+
+    supportsSystem = system: p:
+      lib.libfloco.checkSystemSupportFor p { inherit system; };
+
+  };
+
+
+# ---------------------------------------------------------------------------- #
+
+in noArgs // withArgs // { pdefFilters = { inherit noArgs withArgs; }; }
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/pkgs/cli/src/tasks/list.sh
+++ b/pkgs/cli/src/tasks/list.sh
@@ -31,6 +31,7 @@ global/user configs, or setting the ENV vars \`_[gu]_floco_cfg=null'.
 
 OPTIONS
   -j,--json         Output a JSON list.
+  -f,--filter PRED  Filter results to those satisfying predicate filter.
   -h,--help         Print help message to STDOUT.
   -u,--usage        Print usage message to STDOUT.
   -v,--version      Print version information to STDOUT.
@@ -45,6 +46,21 @@ ENVIRONMENT
   XDG_CONFIG_HOME   Used to find \`XDG_CONFIG_HOME/floco/floco-cfg.{nix,json}'.
   _g_floco_cfg      Path to global floco config file. May be set to \`null'.
   _u_floco_cfg      Path to user floco config file. May be set to \`null'.
+
+FILTERS
+Predicate used by \`--filter' option must be one of the following predefined
+functions defined in \`<floco>/lib/pdef-filters.nix'.
+  hasInstall        Package has a [pre|post]install script.
+  hasBuild          Package has a [pre|post]build script.
+  isLocal           Package's source is fetched from a local path.
+  isRemote          Package's source is fetched from a remote host.
+  isGit             Package's source is a \`git' repository.
+  isTarball         Package's source is a tarball.
+  hasPeers          Package has peer dependencies.
+  hasBundled        Package has bundled dependencies.
+  needsOS           Package supports a limited set of Operating Systems.
+  needsCPU          Package supports a limited set of CPU architectures.
+  needsNodeVersion  Package supports a limited range of Node versions.
 ";
 
 
@@ -100,6 +116,7 @@ while [[ "$#" -gt 0 ]]; do
     -h|--help)     usage -f; exit 0; ;;
     -v|--version)  echo "$_version"; exit 0; ;;
     -j|--json)     _JSON=:; ;;
+    -f|--filter)   _FILTER="$2"; shift; ;;
     --) shift; break; ;;
     -?|--*)
       echo "$_as_me: Unrecognized option: '$1'" >&2;
@@ -128,19 +145,43 @@ done
 
 # ---------------------------------------------------------------------------- #
 
+declare -a _named_filters;
+_named_filters=( $(
+  flocoEval --raw "lib.libfloco.pdefFilters.noArgs"                       \
+    --apply 'f: builtins.concatStringsSep " " ( builtins.attrNames f )';
+) );
+
+if [[ -n "${_FILTER:-}" ]]; then
+  case " ${_named_filters[@]} " in
+    *\ "$_FILTER"\ *) _FILTER="lib.libfloco.pdefFilters.noArgs.$_FILTER"; ;;
+    *)
+      echo "$_as_me: No such filter '$_FILTER'. Must be one of:" >&2;
+      printf ' %s' "" "${_named_filters[@]}" >&2;
+      echo '' >&2;
+      exit 1;
+    ;;
+  esac
+else
+  _FILTER="lib.id";
+fi
+
+
+# ---------------------------------------------------------------------------- #
+
 declare -a _JQ_ARGS;
 _JQ_ARGS=( '-r' );
 if [[ -z "${_JSON:-}" ]]; then
   _JQ_ARGS+=( '.[]' );
 fi
 
-flocoEval --json "$@" mod.config.floco.pdefs --apply 'pdefs:
-builtins.concatLists ( builtins.attrValues ( builtins.mapAttrs ( ident: vs:
+flocoEval --json "$@" mod.config.floco.pdefs --apply "pdefs: let
+  inherit (builtins.getFlake \"$( flocoRef; )\") lib;
+in builtins.concatLists ( builtins.attrValues ( builtins.mapAttrs ( ident: vs:
   builtins.attrValues (
-    builtins.mapAttrs ( version: _: ident + "/" + version ) vs
+    builtins.mapAttrs ( version: _: ident + \"/\" + version ) vs
   )
-) pdefs ) )
-'|$JQ "${_JQ_ARGS[@]}";
+) ( lib.libfloco.filterPdefs $_FILTER pdefs ) ) )
+"|$JQ "${_JQ_ARGS[@]}";
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgs/cli/src/tasks/list.sh
+++ b/pkgs/cli/src/tasks/list.sh
@@ -146,6 +146,7 @@ done
 # ---------------------------------------------------------------------------- #
 
 declare -a _named_filters;
+#shellcheck disable=SC2207
 _named_filters=( $(
   flocoEval --raw "lib.libfloco.pdefFilters.noArgs"                       \
     --apply 'f: builtins.concatStringsSep " " ( builtins.attrNames f )';


### PR DESCRIPTION
Adds `floco list --filter <PREDICATE-NAME>;` option which allows predefined predicates to be used when listing packages.

This is primarily useful for listing packages that have installs and build scripts which may require their own `treeInfo` records; but several filters have been supplied for other use cases.