### PR TITLE
CLI Helper Libs

### DIFF
--- a/pkgs/cli/src/lib/common.sh
+++ b/pkgs/cli/src/lib/common.sh
@@ -44,7 +44,7 @@ else
 fi
 
 SDIR="${SPATH%/*}";
-_as_me="${SPATH##*/}";
+: "${_as_me:=${SPATH##*/}}";
 
 export SPATH SDIR _as_me;
 

--- a/pkgs/cli/src/lib/common.sh
+++ b/pkgs/cli/src/lib/common.sh
@@ -71,69 +71,9 @@ export FLOCO_LIBDIR FLOCO_LIBEXECDIR FLOCO_NIXDIR FLOCO_NIX_LIBDIR;
 #shellcheck source=./nix-system.sh
 . "$FLOCO_LIBDIR/nix-system.sh";
 
-
-# ---------------------------------------------------------------------------- #
-
-# Set the var `_g_floco_cfg' to the "global" floco config file if it exists.
-if [[ -z "${_g_floco_cfg+y}" ]]; then
-  if [[ -r /etc/floco/floco-cfg.nix ]]; then
-    export _g_floco_cfg='/etc/floco/floco-cfg.nix';
-  elif [[ -r /etc/floco/floco-cfg.json ]]; then
-    export _g_floco_cfg='/etc/floco/floco-cfg.json';
-  else
-    export _g_floco_cfg=;
-  fi
-fi
-
-
-# ---------------------------------------------------------------------------- #
-
-# Set the var `_u_floco_cfg' to the "user" floco config file if it exists.
-: "${XDG_CONFIG_HOME:=${HOME:-/homeless/shelter}/.config}";
-export XDG_CONFIG_HOME;
-
-if [[ -z "${_u_floco_cfg+y}" ]]; then
-  if [[ -r $XDG_CONFIG_HOME/floco/floco-cfg.nix ]]; then
-    export _u_floco_cfg="$XDG_CONFIG_HOME/floco/floco-cfg.nix";
-  elif [[ -r $XDG_CONFIG_HOME/floco/floco-cfg.json ]]; then
-    export _u_floco_cfg="$XDG_CONFIG_HOME/floco/floco-cfg.json";
-  else
-    export _u_floco_cfg=;
-  fi
-fi
-
-
-# ---------------------------------------------------------------------------- #
-
-: "${_l_floco_cfg=}";
-export _l_floco_cfg;
-
-# Lazily locate the closest `floco-cfg.{json,nix}' between `PWD' and the closest
-# repository root, or filesystem root.
-localFlocoCfg() {
-  if [[ -z "${_l_floco_cfg:=$( searchUp floco-cfg.nix||:; )}" ]]; then
-    unset _floco_cfg;
-    if [[ -z "${_l_floco_cfg:=$( searchUp floco-cfg.json||:; )}" ]]; then
-      echo "$_as_me: no floco-cfg.nix or floco-cfg.json found" >&2;
-      return 1;
-    fi
-  fi
-  echo "$_l_floco_cfg";
-}
-export -f localFlocoCfg;
-
-
-# ---------------------------------------------------------------------------- #
-
-# Print all the floco config files that are "in scope".
-flocoCfgFiles() {
-  if [[ -n "$_g_floco_cfg" ]]; then echo "$_g_floco_cfg"; fi
-  if [[ -n "$_u_floco_cfg" ]]; then echo "$_u_floco_cfg"; fi
-  {
-    if [[ -n "$( localFlocoCfg||:; )" ]]; then echo "$_l_floco_cfg"; fi
-  } 2>/dev/null;
-}
-export -f flocoCfgFiles;
+#shellcheck source-path=SCRIPTDIR
+#shellcheck source=./configs.sh
+. "$FLOCO_LIBDIR/configs.sh";
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgs/cli/src/lib/common.sh
+++ b/pkgs/cli/src/lib/common.sh
@@ -67,6 +67,10 @@ export FLOCO_LIBDIR FLOCO_LIBEXECDIR FLOCO_NIXDIR FLOCO_NIX_LIBDIR;
 #shellcheck source=./floco-ref.sh
 . "$FLOCO_LIBDIR/floco-ref.sh";
 
+#shellcheck source-path=SCRIPTDIR
+#shellcheck source=./nix-system.sh
+. "$FLOCO_LIBDIR/nix-system.sh";
+
 
 # ---------------------------------------------------------------------------- #
 
@@ -130,21 +134,6 @@ flocoCfgFiles() {
   } 2>/dev/null;
 }
 export -f flocoCfgFiles;
-
-
-# ---------------------------------------------------------------------------- #
-
-# Records the running system pair as recognized by `nix CMD --system SYSTEM'.
-: "${_nix_system=}";
-export _nix_system;
-
-nixSystem() {
-  if [[ -z "$_nix_system" ]]; then
-    _nix_system="$( $NIX eval --raw --impure --expr builtins.currentSystem; )";
-  fi
-  echo "$_nix_system";
-}
-export -f nixSystem;
 
 
 # ---------------------------------------------------------------------------- #

--- a/pkgs/cli/src/lib/configs.sh
+++ b/pkgs/cli/src/lib/configs.sh
@@ -1,0 +1,142 @@
+#! /usr/bin/env bash
+# ============================================================================ #
+#
+# Helpers to locate `floco' configuration files.
+#
+# ---------------------------------------------------------------------------- #
+
+if [[ -n "${_floco_cli_configs_sourced:-}" ]]; then return 0; fi
+
+
+# ---------------------------------------------------------------------------- #
+
+set -eu;
+set -o pipefail;
+
+
+# ---------------------------------------------------------------------------- #
+
+: "${_as_me:=configs.sh}";
+
+
+# ---------------------------------------------------------------------------- #
+
+: "${REALPATH:=realpath}"
+export REALPATH;
+
+
+# ---------------------------------------------------------------------------- #
+
+: "${FLOCO_LIBDIR:=$( $REALPATH "${BASH_SOURCE[0]%/*}"; )}";
+export FLOCO_LIBDIR;
+
+
+# ---------------------------------------------------------------------------- #
+
+# Source Helpers
+
+#shellcheck source-path=SCRIPTDIR
+#shellcheck source=./search-up.sh
+. "$FLOCO_LIBDIR/search-up.sh";
+
+
+# ---------------------------------------------------------------------------- #
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  # Make this file usable as a script.
+  # If an argument is given print ref associated with the given directory.
+  if [[ "$#" -gt 1 ]]; then
+    echo "$_as_me: You may pass at most a single argument." >&2;
+    exit 1;
+  elif [[ "$#" -gt 0 ]]; then
+    if [[ -d "$1" ]]; then
+      pushd "$1" >/dev/null||exit;
+    else
+      echo "$_as_me: No such directory '$1'." >&2;
+      exit 1;
+    fi
+  fi
+fi
+
+
+# ---------------------------------------------------------------------------- #
+
+# Set the var `_g_floco_cfg' to the "global" floco config file if it exists.
+if [[ -z "${_g_floco_cfg+y}" ]]; then
+  if [[ -r /etc/floco/floco-cfg.nix ]]; then
+    export _g_floco_cfg='/etc/floco/floco-cfg.nix';
+  elif [[ -r /etc/floco/floco-cfg.json ]]; then
+    export _g_floco_cfg='/etc/floco/floco-cfg.json';
+  else
+    export _g_floco_cfg=;
+  fi
+fi
+
+
+# ---------------------------------------------------------------------------- #
+
+# Set the var `_u_floco_cfg' to the "user" floco config file if it exists.
+: "${XDG_CONFIG_HOME:=${HOME:-/homeless/shelter}/.config}";
+export XDG_CONFIG_HOME;
+
+if [[ -z "${_u_floco_cfg+y}" ]]; then
+  if [[ -r $XDG_CONFIG_HOME/floco/floco-cfg.nix ]]; then
+    export _u_floco_cfg="$XDG_CONFIG_HOME/floco/floco-cfg.nix";
+  elif [[ -r $XDG_CONFIG_HOME/floco/floco-cfg.json ]]; then
+    export _u_floco_cfg="$XDG_CONFIG_HOME/floco/floco-cfg.json";
+  else
+    export _u_floco_cfg=;
+  fi
+fi
+
+
+# ---------------------------------------------------------------------------- #
+
+: "${_l_floco_cfg=}";
+export _l_floco_cfg;
+
+# Lazily locate the closest `floco-cfg.{json,nix}' between `PWD' and the closest
+# repository root, or filesystem root.
+localFlocoCfg() {
+  if [[ -z "${_l_floco_cfg:=$( searchUp floco-cfg.nix||:; )}" ]]; then
+    if [[ -z "${_l_floco_cfg:=$( searchUp floco-cfg.json||:; )}" ]]; then
+      echo "$_as_me: no floco-cfg.nix or floco-cfg.json found" >&2;
+      return 1;
+    else
+      export _l_floco_cfg;
+    fi
+  else
+    export _l_floco_cfg;
+  fi
+  echo "$_l_floco_cfg";
+}
+export -f localFlocoCfg;
+
+
+# ---------------------------------------------------------------------------- #
+
+# Print all the floco config files that are "in scope".
+flocoCfgFiles() {
+  if [[ -n "$_g_floco_cfg" ]]; then echo "$_g_floco_cfg"; fi
+  if [[ -n "$_u_floco_cfg" ]]; then echo "$_u_floco_cfg"; fi
+  if [[ -n "$( localFlocoCfg 2>/dev/null||:; )" ]]; then localFlocoCfg; fi
+}
+export -f flocoCfgFiles;
+
+
+# ---------------------------------------------------------------------------- #
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  # Make this file usable as a script.
+  # A similar block above handles changing `PWD'.
+  flocoCfgFiles;
+else
+  export _floco_cli_configs_sourced=:;
+fi
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #

--- a/pkgs/cli/src/lib/floco-ref.sh
+++ b/pkgs/cli/src/lib/floco-ref.sh
@@ -48,11 +48,7 @@ export FLOCO_LIBDIR;
 export _floco_ref;
 
 flocoRef() {
-  : "${_floco_ref=}";
-  if [[ -n "$_floco_ref" ]]; then
-    echo "$_floco_ref";
-    return 0;
-  fi
+  if [[ -n "$_floco_ref" ]]; then echo "$_floco_ref"; return 0; fi
 
   local flock;
   if [[ -n "${flock=$( searchUp flake.lock||:; )}" ]]; then
@@ -89,6 +85,7 @@ end
     }|$HEAD -n1;
   )";
   _floco_ref="${_floco_ref##* }";
+  export _floco_ref;
 
   echo "$_floco_ref";
 }

--- a/pkgs/cli/src/lib/nix-system.sh
+++ b/pkgs/cli/src/lib/nix-system.sh
@@ -32,6 +32,7 @@ nixSystem() {
     _nix_system="$( $NIX eval --raw --impure --expr builtins.currentSystem; )";
   fi
   echo "$_nix_system";
+  export _nix_system;
 }
 export -f nixSystem;
 

--- a/pkgs/cli/src/lib/nix-system.sh
+++ b/pkgs/cli/src/lib/nix-system.sh
@@ -1,0 +1,53 @@
+#! /usr/bin/env bash
+# ============================================================================ #
+#
+# Print the running machine's `nix' system pair.
+# Examples:  x86_64-linux, aarch64-linux, x86_64-darwin, etc...
+#
+# ---------------------------------------------------------------------------- #
+
+if [[ -n "${_floco_cli_nix_system_sourced:-}" ]]; then return 0; fi
+
+
+# ---------------------------------------------------------------------------- #
+
+set -eu;
+set -o pipefail;
+
+
+# ---------------------------------------------------------------------------- #
+
+: "${NIX:=nix}"
+export NIX;
+
+
+# ---------------------------------------------------------------------------- #
+
+# Records the running system pair as recognized by `nix CMD --system SYSTEM'.
+: "${_nix_system=}";
+export _nix_system;
+
+nixSystem() {
+  if [[ -z "$_nix_system" ]]; then
+    _nix_system="$( $NIX eval --raw --impure --expr builtins.currentSystem; )";
+  fi
+  echo "$_nix_system";
+}
+export -f nixSystem;
+
+
+# ---------------------------------------------------------------------------- #
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  # Make this file usable as a script.
+  nixSystem;
+else
+  export _floco_cli_nix_system_sourced=:;
+fi
+
+
+# ---------------------------------------------------------------------------- #
+#
+#
+#
+# ============================================================================ #


### PR DESCRIPTION
This is a minor code reorg/refactor to avoid processing unused code.

Move more parts of `common.sh` to helper libraries.

The end goal is to drop the inclusion of most of these helpers from `common.sh` and instead have scripts which use lib routines source them directly; but for now they are sourced to avoid breaking existing scripts.