### PR TITLE
fix(treeFromInfo.nix): Argument list too long

### DIFF
--- a/builders/treeFromInfo.nix
+++ b/builders/treeFromInfo.nix
@@ -92,7 +92,7 @@ in {
     PATH    = "${coreutils}/bin:${findutils}/bin:${jq}/bin:${bash}/bin";
     args = ["-eu" "-o" "pipefail" "-c" ( ''
       mkdir -p "$out/node_modules";
-    '' + cmdFile.text )];
+    '' + "bash ${cmdFile}" )];
   };
 
 


### PR DESCRIPTION
error: executing '/nix/store/XXX-bash-5.2-p15/bin/bash': Argument list too long